### PR TITLE
DM-15 Remove Klarna Payment Option auto-selection

### DIFF
--- a/CKODemoShop/ClientApp/src/app/services/payments.service.ts
+++ b/CKODemoShop/ClientApp/src/app/services/payments.service.ts
@@ -699,6 +699,7 @@ export class PaymentsService {
         case 'klarna': {
           this.paymentDetails.get('capture').setValue(false);
           this.setupPaymentAction(this.klarnaPaymentFlow);
+          this.klarnaCreditSessionResponse.enable();
 
           let requestKlarnaCreditSession = () => this.requestKlarnaSession(this.klarnaCreditSession.value).subscribe(klarnaCreditSessionResponse => handleKlarnaCreditSessionResponse(klarnaCreditSessionResponse));
           let handleKlarnaCreditSessionResponse = async (klarnaCreditSessionResponse: HttpResponse<any>) => {
@@ -1026,7 +1027,7 @@ export class PaymentsService {
   }
 
   get paymentButtonIsDisabled(): boolean {
-    return (this.paymentDetails ? this.paymentDetails.invalid : false) || (this.paymentConsent ? this.paymentConsent.invalid : false) || this._processing;
+    return (this.paymentDetails ? this.paymentDetails.invalid : false) || (this.paymentConsent ? this.paymentConsent.invalid : false) || (this.klarnaCreditSessionResponse ? this.klarnaCreditSessionResponse.invalid : false) || this._processing;
   }
 
   get currencies(): ICurrency[] {
@@ -1069,6 +1070,8 @@ export class PaymentsService {
     this.threeDs = true;
     this.paymentConsent.reset();
     this.paymentConsent.disable();
+    this.klarnaCreditSessionResponse.reset();
+    this.klarnaCreditSessionResponse.disable();
     this.setProcessing(false);
   }
 

--- a/CKODemoShop/ClientApp/src/app/services/payments.service.ts
+++ b/CKODemoShop/ClientApp/src/app/services/payments.service.ts
@@ -717,7 +717,6 @@ export class PaymentsService {
                 document.querySelector('#klarna-container').innerHTML = '';
               }
               if ((klarnaCreditSessionResponse.body.payment_method_categories as []).length > 0) {
-                this.klarnaCreditSessionResponse.get('selected_payment_method_category').setValue(klarnaCreditSessionResponse.body.payment_method_categories[0].identifier);
                 await this._scriptService.load('klarna');
                 await klarnaPaymentsInit(klarnaCreditSessionResponse.body.client_token);
                 await klarnaPaymentsLoad();


### PR DESCRIPTION
[DM-15 Remove Klarna Payment Option auto-selection](https://checkout.atlassian.net/browse/DM-15)

When presenting Klarna Payment Options, the app auto-selects the first option.
It is better if the options remain unselected until explicitly selected by the shopper.

Should:

1. remove code for auto-selection of Klarna Payment Option
2. handle payment flow to disable “Pay Now” button, if Klarna Payment Option is not selected